### PR TITLE
tween player movement for better gamefeel

### DIFF
--- a/Scenes/world.tscn
+++ b/Scenes/world.tscn
@@ -148,6 +148,7 @@ texture = ExtResource("1_7gmgy")
 
 [sub_resource type="TileSet" id="TileSet_kl3hf"]
 physics_layer_0/collision_layer = 1
+navigation_layer_0/layers = 1
 sources/0 = SubResource("TileSetAtlasSource_dywxk")
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0otx2"]

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -1,7 +1,11 @@
 extends Area2D
 
+#onready vars to reference other nodes and manipulate their values
 @onready var PlayerAnim = $AnimatedSprite2D
 @onready var Ray = $RayCast2D
+
+var animationSpeed = 18 #tweening speed
+var moving = false #keeps us from glitching out movement
 
 var tileSize = 16
 var inputs = {"Up": Vector2.UP,
@@ -15,6 +19,9 @@ func _ready():
 	PlayerAnim.play("Idle")
 
 func _input(event):
+	if moving:
+		#if we're already tweening movement, don't move again
+		return
 	for dir in inputs.keys():
 		if event.is_action_pressed("Left"):
 			PlayerAnim.flip_h = true
@@ -24,7 +31,12 @@ func _input(event):
 			move(dir)
 
 func move(dir):
-	Ray.target_position = inputs[dir] * tileSize
+	Ray.target_position = inputs[dir] * tileSize	#set ray to move direction +16 pixels
 	Ray.force_raycast_update()
-	if !Ray.is_colliding():
-		position += inputs[dir] * tileSize
+	if !Ray.is_colliding(): #if ray is colliding with a wall, we can't move there
+		var tween = create_tween() #create a new Tween object to handle smooth movement
+		#tween the position property of self to a position of +16 pixels in the input direction, on a sin curve
+		tween.tween_property(self, "position", position + inputs[dir] * tileSize, 1.0/animationSpeed).set_trans(Tween.TRANS_SINE)
+		moving = true #set this to true until tween is finished to disallow multiple moves at once
+		await tween.finished
+		moving = false


### PR DESCRIPTION
Added a small movement smoothing tween when the player moves instead of snapping directly to the next tile. Tween time set to 1/18 second. Checks are in place to disallow multiple moves at once and off-grid movement.