### PR TITLE
add plugin ignoring for individual plugin managing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+
+# object files
 *.o
 *.exe
+
+# plugins
+addons/


### PR DESCRIPTION
I want to add Godot plugins, which need to be added to the project folder, but that would require you all to have them as well, whereas I think plugins should be individually chosen. Added addons/ to .gitignore to fix this issue.

Also, extremely convenient that I wanted to do this while Grant is going over pull requests :)