### PR TITLE
pulled player and map gen out of world

### DIFF
--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=8 format=3 uid="uid://68ijyklfqgk8"]
+
+[ext_resource type="Script" path="res://Scripts/Player.gd" id="1_y1cbo"]
+[ext_resource type="Texture2D" uid="uid://cfev8eg0mvn0p" path="res://Textures/Tilemaps/DungeonCave/Heroes-Animated.png" id="2_r5mdx"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0otx2"]
+atlas = ExtResource("2_r5mdx")
+region = Rect2(16, 16, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_hy0ej"]
+atlas = ExtResource("2_r5mdx")
+region = Rect2(32, 16, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7hlr5"]
+atlas = ExtResource("2_r5mdx")
+region = Rect2(48, 16, 16, 16)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_0l2wx"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0otx2")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_hy0ej")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7hlr5")
+}],
+"loop": true,
+"name": &"Idle",
+"speed": 4.0
+}]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_2cp1y"]
+size = Vector2(16, 16)
+
+[node name="Player" type="Area2D"]
+z_index = 1
+position = Vector2(216, 152)
+script = ExtResource("1_y1cbo")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+sprite_frames = SubResource("SpriteFrames_0l2wx")
+animation = &"Idle"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+shape = SubResource("RectangleShape2D_2cp1y")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+zoom = Vector2(3, 3)
+
+[node name="RayCast2D" type="RayCast2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+target_position = Vector2(0, 16)

--- a/Scenes/map_gen.tscn
+++ b/Scenes/map_gen.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://cwh61ulkoa1eh"]
+
+[ext_resource type="Script" path="res://Scripts/map_gen.gd" id="1_i2k73"]
+
+[node name="map_gen" type="Node2D"]
+script = ExtResource("1_i2k73")

--- a/Scenes/temp.tscn
+++ b/Scenes/temp.tscn
@@ -1,0 +1,60 @@
+[gd_scene load_steps=8 format=3 uid="uid://b04jb1bracxia"]
+
+[ext_resource type="Script" path="res://Scripts/Player.gd" id="1_giwdq"]
+[ext_resource type="Texture2D" uid="uid://cfev8eg0mvn0p" path="res://Textures/Tilemaps/DungeonCave/Heroes-Animated.png" id="2_1sfjo"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0otx2"]
+atlas = ExtResource("2_1sfjo")
+region = Rect2(16, 16, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_hy0ej"]
+atlas = ExtResource("2_1sfjo")
+region = Rect2(32, 16, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7hlr5"]
+atlas = ExtResource("2_1sfjo")
+region = Rect2(48, 16, 16, 16)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_0l2wx"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_0otx2")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_hy0ej")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7hlr5")
+}],
+"loop": true,
+"name": &"Idle",
+"speed": 4.0
+}]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_2cp1y"]
+size = Vector2(16, 16)
+
+[node name="Player" type="Area2D"]
+z_index = 1
+position = Vector2(216, 152)
+script = ExtResource("1_giwdq")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+sprite_frames = SubResource("SpriteFrames_0l2wx")
+animation = &"Idle"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+shape = SubResource("RectangleShape2D_2cp1y")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+zoom = Vector2(3, 3)
+
+[node name="RayCast2D" type="RayCast2D" parent="."]
+position = Vector2(0.00147247, -0.0235901)
+target_position = Vector2(0, 16)
+
+[node name="temp" type="Node2D" parent="."]

--- a/Scenes/world.tscn
+++ b/Scenes/world.tscn
@@ -1,43 +1,8 @@
-[gd_scene load_steps=13 format=3 uid="uid://cqqguphmvsvh8"]
+[gd_scene load_steps=5 format=3 uid="uid://cqqguphmvsvh8"]
 
 [ext_resource type="Script" path="res://Scripts/World.gd" id="1_mmcn7"]
-[ext_resource type="Script" path="res://Scripts/Player.gd" id="2_trmsc"]
-[ext_resource type="Texture2D" uid="uid://cfev8eg0mvn0p" path="res://Textures/Tilemaps/DungeonCave/Heroes-Animated.png" id="3_6w2ow"]
-[ext_resource type="Script" path="res://Scripts/map_gen.gd" id="4_33hq0"]
 [ext_resource type="Script" path="res://Core/UIManager.gd" id="5_7qe8y"]
 [ext_resource type="Texture2D" uid="uid://o403j52a0dp4" path="res://Textures/Tilemaps/UI/Icons.png" id="6_3lq2y"]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_0otx2"]
-atlas = ExtResource("3_6w2ow")
-region = Rect2(16, 16, 16, 16)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_hy0ej"]
-atlas = ExtResource("3_6w2ow")
-region = Rect2(32, 16, 16, 16)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_7hlr5"]
-atlas = ExtResource("3_6w2ow")
-region = Rect2(48, 16, 16, 16)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_q1x14"]
-animations = [{
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_0otx2")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_hy0ej")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_7hlr5")
-}],
-"loop": true,
-"name": &"Idle",
-"speed": 4.0
-}]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_fy2yg"]
-size = Vector2(16, 16)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_c3j6l"]
 atlas = ExtResource("6_3lq2y")
@@ -45,31 +10,6 @@ region = Rect2(16, 256, 16, 16)
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_mmcn7")
-
-[node name="Player" type="Area2D" parent="."]
-z_index = 1
-position = Vector2(216, 152)
-script = ExtResource("2_trmsc")
-
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="Player"]
-position = Vector2(0.00147247, -0.0235901)
-sprite_frames = SubResource("SpriteFrames_q1x14")
-animation = &"Idle"
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Player"]
-position = Vector2(0.00147247, -0.0235901)
-shape = SubResource("RectangleShape2D_fy2yg")
-
-[node name="Camera2D" type="Camera2D" parent="Player"]
-position = Vector2(0.00147247, -0.0235901)
-zoom = Vector2(3, 3)
-
-[node name="RayCast2D" type="RayCast2D" parent="Player"]
-position = Vector2(0.00147247, -0.0235901)
-target_position = Vector2(0, 16)
-
-[node name="map_gen" type="Node2D" parent="."]
-script = ExtResource("4_33hq0")
 
 [node name="UIManager" type="CanvasLayer" parent="."]
 script = ExtResource("5_7qe8y")
@@ -85,5 +25,3 @@ offset_top = 8.0
 offset_right = 104.0
 offset_bottom = 40.0
 text = "0"
-
-[connection signal="input_event" from="Player" to="." method="_on_player_input_event"]

--- a/Scripts/World.gd
+++ b/Scripts/World.gd
@@ -5,6 +5,14 @@ var turnCounter = 0;
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	var player = preload("res://Scenes/Player.tscn").instantiate()
+	add_child(player)
+	
+	
+	
+	var instance = preload("res://Scenes/map_gen.tscn")
+	var level = instance.instantiate()
+	add_child(level)
 	pass # Replace with function body.
 
 #function to take a turn, should basically wait for the player signal then handle all the enemies


### PR DESCRIPTION
Removed player and map gen from world scene file and created two separate scene. Reconnected them back to world script. This should allow us to control our root node and scene changing for menus and level progression.