### PR TITLE
z index bugfix #2

### DIFF
--- a/Scenes/Monsters/skeleton_warrior.tscn
+++ b/Scenes/Monsters/skeleton_warrior.tscn
@@ -47,11 +47,13 @@ shape = SubResource("RectangleShape2D_3i2wy")
 [node name="RayCast2D" type="RayCast2D" parent="."]
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+z_index = 1
 sprite_frames = SubResource("SpriteFrames_qw51r")
 
 [node name="Area2D" type="Area2D" parent="."]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+z_index = 1
 shape = SubResource("RectangleShape2D_n24i7")
 
 [connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]

--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -36,9 +36,11 @@ animations = [{
 size = Vector2(16, 16)
 
 [node name="Player" type="CharacterBody2D"]
+z_index = 2
 script = ExtResource("1_2lqgk")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+z_index = 2
 position = Vector2(0.00147247, -0.0235901)
 sprite_frames = SubResource("SpriteFrames_5dfc8")
 animation = &"Idle"


### PR DESCRIPTION
Re-fixed z index bug after enemy changes

current index explanation:
(to view value, go to node -> CanvasItem -> Ordering -> Z index)
0 - items
1 - enemies
2 - player
higher values are rendered on top of lower values