### PR TITLE
Tween timing fix

### DIFF
--- a/Core/GameMaster.gd
+++ b/Core/GameMaster.gd
@@ -155,9 +155,11 @@ func calculate_hit_chance(attack, defense):
 	return baseHit - penalty
 
 func animate_attack(attacker, target) -> Tween:
+	if not is_instance_valid(attacker) or not is_instance_valid(target):
+		return get_tree().create_tween()
 	var distance = -8.0
 	var animSpeed = 0.1
-	var originPos = attacker.position
+	var originPos = attacker.position.snapped(Vector2.ONE * -distance)
 	var originColor = attacker.modulate
 	var direction = (attacker.position - target.position).normalized()
 	var offset = direction * distance
@@ -169,7 +171,11 @@ func animate_attack(attacker, target) -> Tween:
 	tween.tween_property(attacker, "position", originPos + offset, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
 	tween.tween_property(attacker, "position", originPos, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
 	#then, we flash the attacked party red by modulating
-	tween.tween_property(target, "modulate", Color.RED, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
-	tween.tween_property(target, "modulate", originColor, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
-	
+	if is_instance_valid(target):
+		tween.tween_property(target, "modulate", Color.RED, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+		tween.tween_property(target, "modulate", originColor, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+	tween.tween_callback(func():
+		if is_instance_valid(attacker):
+			attacker.position = originPos.snapped(Vector2.ONE * -distance)
+	)
 	return tween

--- a/Core/GameMaster.gd
+++ b/Core/GameMaster.gd
@@ -52,91 +52,106 @@ func setname(player_name: String):
 #function to take a turn, should basically wait for the player signal then handle all the enemies
 #made it take any value in case we want faster enemies or slower player debuffs
 func takeTurn(turnsTaken: int):
-	#var player = get_tree().get_first_node_in_group("player")
+	#if can_move flag is false, do nothing
 	if not can_move:
 		return
-	print("Starting player turn")
+	
 	turnCounter += turnsTaken
 	print("Current turn: ",turnCounter);
 	can_move = false
+	
 	#apply over-time effects, increment timers, whatever is appropriate here
-	print("Ending player turn\n")
-	took_turns.emit(1)
+	
+	took_turns.emit(1) #this just sends a signal to the ui turn counter
 	await enemyTurn()
+	await get_tree().process_frame
 	can_move = true
 
 #player and enemy turns are separated out so the player always gets priority over the enemies (unless debuffs change that)
 func enemyTurn():
 	print("Starting enemy turn")
 	var enemies = get_tree().get_nodes_in_group("enemies")
-	for i in range(enemies.size()):
-		var enemy = enemies[i]
-		print("Enemy [", i,"|",enemy.name, "] at position ", enemy.position, " moving in direction ", enemy.vec_to_cardinal(enemy.position.direction_to(enemy.player.position)) if enemy.player else Vector2.ZERO)
+	for enemy in enemies:
+		if not is_instance_valid(enemy):
+			continue  # Skip if enemy has been freed.
+		print("Enemy [", enemy.name, "] at position ", enemy.position)
 		await enemy.take_turn()
 	print("Ending enemy turn\n")
 
 #combat method, this can be changed for balance
 func combat(player, enemy):
+	#lock player
+	can_move = false
+	#grab some information about combatants
 	var playerName = player.player_name
 	var enemyName = enemy.name
-	print("-----Initiating combat between ",playerName," and ",enemyName,"!-----")
-	
-	#take combatant strength - opponent defense as damage, floor to 1. Enemies can do 0 damage to player.
+	var enemyXP = enemy.xp
+	#take combatant strength - opponent defense as damage, floor player to 1 and enemies to 0 damage to favor player some.
 	var playerDamage = max(player.attack - enemy.defense, 1)
-	var enemyDamage = max(enemy.strength - player.armor, 1)
+	var enemyDamage = max(enemy.strength - player.armor, 0)
 	
+	print("-----Initiating combat between ",playerName," and ",enemyName,"!-----")
 	#roll for player's chance to hit
 	var playerHitChance = calculate_hit_chance(player.attack, enemy.defense)
 	var playerRoll = randf()
 	print(playerName," needs less than <",playerHitChance,"> to hit, rolled a <",snapped(playerRoll,0.01),">.")
 	if playerRoll <= playerHitChance:
+		#THIS SHOULD BE A SIGNAL
 		enemy.health -= playerDamage
-		can_move = false
 		var attackTween = animate_attack(player, enemy)
 		await attackTween.finished
-		print(playerName," dealt ",playerDamage," damage to ",enemyName,". ",enemyName," has ",enemy.health," health left.\n")
-		can_move = true
+		if is_instance_valid(enemy):
+			print(playerName," dealt ",playerDamage," damage to ",enemyName,". ",enemyName," has ",enemy.health," health left.\n")
 	else:
 		print(playerName," missed ",enemyName,"!\n")
 	
-	var enemyHitChance = calculate_hit_chance(enemy.strength,player.armor)
-	var enemyRoll = randf()
-	print(enemyName," needs less than <",enemyHitChance,"> to hit, rolled a <",snapped(enemyRoll,0.01),">.")
-	if enemyRoll <= enemyHitChance:
-		damage_player_signal.emit(enemyDamage)
-		can_move = false
-		var attackTween = animate_attack(enemy, player)
-		await attackTween.finished
-		print(enemyName," dealt ",enemyDamage," damage to ",playerName,". ",playerName," has ",player.health," health left.")
-		can_move = true
+	#after player attacks, check if enemy is dead
+	var enemyDefeated
+	if is_instance_valid(enemy):
+		enemyDefeated = enemy.health <= 0
 	else:
-		print(enemyName," missed ",playerName,"!")
+		enemyDefeated = true
 	
-	#if enemy dies, call free
-	if enemy.health <= 0:
+	#if it's alive, roll combat
+	if not enemyDefeated:
+		var enemyHitChance = calculate_hit_chance(enemy.strength,player.armor)
+		var enemyRoll = randf()
+		print(enemyName," needs less than <",enemyHitChance,"> to hit, rolled a <",snapped(enemyRoll,0.01),">.")
+		if enemyRoll <= enemyHitChance:
+			damage_player_signal.emit(enemyDamage)
+			var attackTween = animate_attack(enemy, player)
+			await attackTween.finished
+			print(enemyName," dealt ",enemyDamage," damage to ",playerName,". ",playerName," has ",player.health," health left.")
+		else:
+			print(enemyName," missed ",playerName,"!")
+	
+	#if enemy dies, call free and give player xp
+	if enemyDefeated:
 		print(enemyName," defeated!")
-		player.add_xp(enemy.xp)
-		print(playerName," gained <",enemy.xp,"> xp!")
-		enemy.queue_free()
+		player.add_xp(enemyXP)
+		print(playerName," gained <",enemyXP,"> xp!")
+		if is_instance_valid(enemy):
+			enemy.queue_free()
 	
 	#if player dies, game over. Need Gabe's game over screen called here.
 	if player.health <= 0:
 		print(playerName," died!\n")
+	
+	await get_tree().process_frame
+	can_move = true;
 
 #calculate chance to hit based on difference between attack and armor
 func calculate_hit_chance(attack, defense):
 	var baseHit = 0.90
 	var minHit = 0.40
-	
 	var diff = attack - defense
-	
 	#penalty is applied if diff < 0
 	#for example, if the player has 3 defense vs a skeleton with 1 attack
-	#diff = -2, penalty = 0.20, chance to hit = 0.75
+	#diff = -2, penalty = 0.20, chance to hit = 0.70
 	var penalty = 0.10 * max(-diff,0)
 	#clamp penalty to minHit value so there's always a chance to hit something
 	penalty = clamp(penalty, 0.0, baseHit - minHit)
-	
+	#returns a value from 0.4-0.9, the player must roll below that to hit.
 	return baseHit - penalty
 
 func animate_attack(attacker, target) -> Tween:

--- a/Scenes/Enemies/Cave_Enemies/SkeletonWarrior.tscn
+++ b/Scenes/Enemies/Cave_Enemies/SkeletonWarrior.tscn
@@ -37,7 +37,7 @@ animations = [{
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_n24i7"]
-size = Vector2(48, 48)
+size = Vector2(80, 80)
 
 [node name="Skeleton Warrior" type="CharacterBody2D"]
 script = ExtResource("1_v1fiw")

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -121,9 +121,12 @@ func move(dir) -> bool:
 	#create a new Tween object to handle smooth movement
 	var tween = create_tween()
 	#tween the position property of self to a position of +16 pixels in the input direction, on a sin curve
-	tween.tween_property(self, "position", position + inputs[dir] * tileSize, 1.0/animationSpeed).set_trans(Tween.TRANS_SINE)
+	var target_pos = (position + inputs[dir] * tileSize).snapped(Vector2.ONE * tileSize/2)  # Snap target
+	tween.tween_property(self, "position", target_pos, 1.0/animationSpeed).set_trans(Tween.TRANS_SINE)
 	#set this flag to true until tween is finished to disallow multiple moves at once
 	await tween.finished
+	#just snap back to tile position
+	position = position.snapped(Vector2.ONE * tileSize/2)
 	#emit a movement signal here, after the player succesfully moves
 	emit_signal("input_event")
 	return true

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -35,7 +35,12 @@ var tileSize = 16
 var moveTimer = 0.0  #timer used to count down movement delay
 var moveDelay = 0.15  #movement delay in seconds
 var animationSpeed = 18 #tweening speed
-var moving = false #keeps us from glitching out movement
+
+#this controls movement and combat flow.
+#TRUE if the player is locked into an action. Moving/in combat/looting/whatever
+#FALSE if the player is between turns, before input.
+var moving = false
+
 
 #dict map of input strings to directional vectors
 var inputs = {"Up": Vector2.UP,
@@ -62,9 +67,8 @@ func _ready():
 
 #Called every frame to handle continuous input
 func _process(delta):
-	var hasMoved = false
 	#if we're already tweening movement, don't move again
-	if not GameMaster.can_move or moving:
+	if moving or not GameMaster.can_move:
 		moveTimer = 0.0
 		return
 	
@@ -80,14 +84,19 @@ func _process(delta):
 	#process input, both presses and holds
 	for dir in inputs.keys():
 		#if button is just pressed OR if timer has elapsed and button is held
-		if (Input.is_action_just_pressed(dir) or (moveTimer <= 0 and Input.is_action_pressed(dir))) and not hasMoved:
+		if Input.is_action_just_pressed(dir) or (moveTimer <= 0 and Input.is_action_pressed(dir)):
+			if moving:
+				return
+			moving = true
+			#await everything before we can move again
 			if await move(dir):
-				GameMaster.takeTurn(1)
+				await GameMaster.takeTurn(1)
 			#reset movement timer on succesful move
+			moving = false
 			moveTimer = moveDelay
-			hasMoved = true
 			return
 
+#function to try a move, returns TRUE on succesfull move and FALSE on invalid
 func move(dir) -> bool:
 	if noclip_enabled:
 		# Move freely without collision checks
@@ -105,23 +114,19 @@ func move(dir) -> bool:
 	if Ray.is_colliding():
 		var collider = Ray.get_collider()
 		if collider.is_in_group("enemies"):
-			GameMaster.combat(self, collider)
-			return true
-	else:
-		#create a new Tween object to handle smooth movement
-		var tween = create_tween()
-		#tween the position property of self to a position of +16 pixels in the input direction, on a sin curve
-		tween.tween_property(self, "position", position + inputs[dir] * tileSize, 1.0/animationSpeed).set_trans(Tween.TRANS_SINE)
-		#set this flag to true until tween is finished to disallow multiple moves at once
-		moving = true
-		await tween.finished
-		moving = false
-		#emit a movement signal here, after the player succesfully moves
-		emit_signal("input_event")
-		moveTimer = moveDelay
-		return true
-	moveTimer = moveDelay
-	return false
+			if Input.is_action_just_pressed(dir):
+				await GameMaster.combat(self, collider)
+				return true
+		return false
+	#create a new Tween object to handle smooth movement
+	var tween = create_tween()
+	#tween the position property of self to a position of +16 pixels in the input direction, on a sin curve
+	tween.tween_property(self, "position", position + inputs[dir] * tileSize, 1.0/animationSpeed).set_trans(Tween.TRANS_SINE)
+	#set this flag to true until tween is finished to disallow multiple moves at once
+	await tween.finished
+	#emit a movement signal here, after the player succesfully moves
+	emit_signal("input_event")
+	return true
 
 func add_xp(amount: int):
 	currentXP += amount

--- a/Scripts/command_line.gd
+++ b/Scripts/command_line.gd
@@ -72,7 +72,7 @@ func process_command(command, option = "", num = ""):
 			var cur_room = ($"../Player".global_position) / 272
 			print(cur_room)
 			print(cur_room.floor())
-		"combatlogs":
+		"logs":
 			GameMaster.DEBUG_COMBATLOGS = !GameMaster.DEBUG_COMBATLOGS
 			if GameMaster.DEBUG_COMBATLOGS == true:
 				command_history.append("Verbose combat logs enabled.")

--- a/Scripts/command_line.gd
+++ b/Scripts/command_line.gd
@@ -72,5 +72,11 @@ func process_command(command, option = "", num = ""):
 			var cur_room = ($"../Player".global_position) / 272
 			print(cur_room)
 			print(cur_room.floor())
+		"combatlogs":
+			GameMaster.DEBUG_COMBATLOGS = !GameMaster.DEBUG_COMBATLOGS
+			if GameMaster.DEBUG_COMBATLOGS == true:
+				command_history.append("Verbose combat logs enabled.")
+			else:
+				command_history.append("Verbose combat logs disabled.")
 		_:
 			command_history.append("Unknown command: " + command)


### PR DESCRIPTION
- Added a bunch more awaits and flags to movement to make sure that players cannot take invalid turns or clip into enemies.
- Everything with a tween actually awaits that tween to be finished to prevent race conditions
- Updated the outdated move function in skeleton_warrior.gd
- Reworked combat flow to disallow holding down an input key during combat, each turn must be explicitly declared by the player
- After combat, combatants are snapped back to the center of the tile as a failsafe