### PR TITLE
Bugfixes, balance, and particle tweaks

### DIFF
--- a/Core/GameMaster.gd
+++ b/Core/GameMaster.gd
@@ -206,7 +206,7 @@ func combat(player, enemy):
 	var enemyXP = enemy.xp
 	#take combatant strength - opponent defense as damage, floor player to 1 and enemies to 0 damage to favor player some.
 	var playerDamage = max(player.attack - enemy.defense, 1)
-	var enemyDamage = max(enemy.strength - player.armor, 0)
+	var enemyDamage = max(enemy.strength - player.armor, 1)
 	
 	if DEBUG_COMBATLOGS:
 		print("-----Initiating combat between ",playerName," and ",enemyName,"!-----")
@@ -310,7 +310,7 @@ func animate_attack(attacker, target) -> Tween:
 	tween.tween_property(target, "modulate", originColor, animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
 	tween.tween_callback(func():
 		if is_instance_valid(attacker):
-			attacker.call_deferred("position", originPos.snapped(Vector2.ONE * -distance))
+			attacker.set_deferred("position", originPos.snapped(Vector2.ONE * -distance))
 	)
 	return tween
 
@@ -327,7 +327,7 @@ func animate_miss(attacker) -> Tween:
 		tween.tween_property(attacker, "position", originPos - Vector2(offset, 0), animSpeed).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
 	tween.tween_callback(func():
 		if is_instance_valid(attacker):
-			attacker.call_deferred("position", originPos.snapped(Vector2.ONE * -8))
+			attacker.set_deferred("position", originPos.snapped(Vector2.ONE * -8))
 	)
 	return tween
 

--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://dbx8ypfrhdjsj"]
+[gd_scene load_steps=23 format=3 uid="uid://dbx8ypfrhdjsj"]
 
 [ext_resource type="Script" uid="uid://bbgf6o5pomr3j" path="res://Scripts/Player.gd" id="1_2lqgk"]
 [ext_resource type="Texture2D" uid="uid://cfev8eg0mvn0p" path="res://Textures/Tilemaps/DungeonCave/Heroes-Animated.png" id="2_qilt3"]
@@ -6,20 +6,37 @@
 [ext_resource type="Texture2D" uid="uid://cnrhr7328bg3j" path="res://Textures/Tilemaps/custom/Hero-Invisible.png" id="4_dewec"]
 [ext_resource type="Shader" uid="uid://7hlalx4wngds" path="res://Shaders/invert_colors.gdshader" id="5_5ixxa"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_2lx3f"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_bhhdu"]
 atlas = ExtResource("2_tdieg")
-region = Rect2(16, 64, 16, 16)
+region = Rect2(16, 224, 16, 16)
+
+[sub_resource type="Curve" id="Curve_megsn"]
+_data = [Vector2(0, 0.595506), 0.0, 0.0, 0, 0, Vector2(0.522727, 0.370787), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 3
+
+[sub_resource type="Gradient" id="Gradient_yoq75"]
+offsets = PackedFloat32Array(0.0133333, 0.18, 0.4, 0.606667, 0.8, 1)
+colors = PackedColorArray(1, 1, 1, 1, 0.932013, 0.794745, 0, 1, 1, 1, 1, 1, 0.933333, 0.796078, 0, 1, 1, 1, 1, 1, 0.933333, 0.796078, 0, 1)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ksbbd"]
+atlas = ExtResource("2_tdieg")
+region = Rect2(80, 352, 16, 16)
 
 [sub_resource type="Curve" id="Curve_on12k"]
-_data = [Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
-point_count = 2
+_data = [Vector2(0, 0.775281), 0.0, 0.0, 0, 0, Vector2(0.619318, 0.573034), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 3
 
 [sub_resource type="Gradient" id="Gradient_3ff0n"]
 offsets = PackedFloat32Array(0.06, 0.246667, 0.526667, 0.746667, 1)
 colors = PackedColorArray(0.329412, 1, 0, 1, 0.902941, 1, 0, 1, 0.425, 1, 0, 1, 0.786631, 1, 0, 1, 0.329412, 1, 0, 1)
 
+[sub_resource type="AtlasTexture" id="AtlasTexture_2lx3f"]
+atlas = ExtResource("2_tdieg")
+region = Rect2(16, 64, 16, 16)
+
 [sub_resource type="Gradient" id="Gradient_dewec"]
-colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1)
+offsets = PackedFloat32Array(0, 0.526667, 1)
+colors = PackedColorArray(1, 1, 1, 1, 0.552956, 0.552956, 0.552956, 1, 0, 0, 0, 0)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0otx2"]
 atlas = ExtResource("2_qilt3")
@@ -92,9 +109,32 @@ z_index = 2
 script = ExtResource("1_2lqgk")
 
 [node name="LevelUpParticles2D" type="CPUParticles2D" parent="."]
+emitting = false
+amount = 32
+texture = SubResource("AtlasTexture_bhhdu")
+lifetime = 1.5
+one_shot = true
+speed_scale = 2.0
+explosiveness = 1.0
+emission_shape = 2
+emission_sphere_radius = 1.0
+spread = 180.0
+gravity = Vector2(0, 0)
+initial_velocity_min = 32.0
+initial_velocity_max = 40.0
+angular_velocity_min = 32.0
+angular_velocity_max = 40.0
+orbit_velocity_min = 0.5
+orbit_velocity_max = 0.75
+scale_amount_curve = SubResource("Curve_megsn")
+color_ramp = SubResource("Gradient_yoq75")
+
+[node name="HealParticles2D" type="CPUParticles2D" parent="."]
 z_index = 2
 emitting = false
-texture = SubResource("AtlasTexture_2lx3f")
+amount = 16
+texture = SubResource("AtlasTexture_ksbbd")
+lifetime = 0.9
 one_shot = true
 speed_scale = 2.0
 explosiveness = 1.0
@@ -114,18 +154,17 @@ hue_variation_max = 1.0
 [node name="BecomeInvisibleParticles2D" type="CPUParticles2D" parent="."]
 z_index = 2
 emitting = false
+amount = 24
 texture = SubResource("AtlasTexture_2lx3f")
+lifetime = 1.75
 one_shot = true
 speed_scale = 2.0
 explosiveness = 1.0
+lifetime_randomness = 0.5
 spread = 180.0
 gravity = Vector2(0, 0)
 initial_velocity_min = 8.0
 initial_velocity_max = 16.0
-angular_velocity_min = -8.0
-angular_velocity_max = 8.0
-orbit_velocity_min = 0.15
-orbit_velocity_max = 0.15
 scale_amount_curve = SubResource("Curve_on12k")
 color_ramp = SubResource("Gradient_dewec")
 hue_variation_min = 1.0

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -22,7 +22,7 @@ extends CharacterBody2D
 #base player stats to be affected by levels/potions
 @export var player_name = ""
 @export var health = 10
-@export var MAX_HEALTH = 15
+@export var MAX_HEALTH = 10
 @export var level = 1
 @export var currentXP = 0
 var XPtoNext = 10
@@ -162,6 +162,8 @@ func gain_level():
 		currentXP -= XPtoNext
 		level += 1
 		XPtoNext = 10 * (level ** 2)
+		MAX_HEALTH = MAX_HEALTH + 5
+		health = MAX_HEALTH
 		strength += 1
 		defense += 1
 		attack += 1
@@ -229,6 +231,7 @@ func _on_damage_received(amount: int):
 
 func _on_heal_received(amount: int):
 	if health < MAX_HEALTH:
+		$HealParticles2D.emitting = true
 		health = min(MAX_HEALTH, health+amount)
 	#print("Player healed ", amount, " points. New health:", health)
 


### PR DESCRIPTION
- fixed the tweening errors by changing call_deferred to set_deferred to correctly handle properties of nodes
- increased the player's health by 5 per level-up as well as resetting their health on level-up
- added a better level-up particle effect that is triggered when the player levels
- the old level-up particle effect has been repurposed into a heal particle effect when the player is healed and below max health
- slightly tweaked the smoke effect for invisibility while I was looking at particles