### PR TITLE
Shader Fix

### DIFF
--- a/Scenes/Player.tscn
+++ b/Scenes/Player.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://cnrhr7328bg3j" path="res://Textures/Tilemaps/custom/Hero-Invisible.png" id="4_dewec"]
 [ext_resource type="Texture2D" uid="uid://j2uot8ig0ji0" path="res://Textures/Tilemaps/custom/Hero-Poisoned.png" id="5_52ee3"]
 [ext_resource type="Texture2D" uid="uid://bvvmu07fdmyqh" path="res://Textures/Tilemaps/custom/Hero-Stat-Boost.png" id="6_bhhdu"]
-[ext_resource type="Shader" uid="uid://c68x7jr8hyfob" path="res://Shaders/darken_colors.gdshader" id="7_52ee3"]
+[ext_resource type="Shader" uid="uid://7hlalx4wngds" path="res://Shaders/invert_colors.gdshader" id="7_52ee3"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_bhhdu"]
 atlas = ExtResource("2_tdieg")

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -55,7 +55,7 @@ const BLIND_LENGTH = 40
 ## scroll effects
 @export var is_stat_boosted = false
 const STAT_BOOST_LENGTH = 15
-@export var stats_before_stat_boost = []
+@export var stats_before_stat_boost = [attack, armor]
 
 ## effects from enemies
 @export var is_frozen = false # doesn't do anything, just an example - remove if needed


### PR DESCRIPTION
- fixed invert colors shader (was assigned darken shader for some reason)
- initialized player variable stats_before_stat_boost to avoid out-of-bounds crashes